### PR TITLE
Unassigned users by mr skeleton fox

### DIFF
--- a/src/main/java/api_tests/mentor/WHAT_163.java
+++ b/src/main/java/api_tests/mentor/WHAT_163.java
@@ -17,7 +17,7 @@ public class WHAT_163 extends BaseTest {
     public void updateInformationAboutMentors200Admin(){
         String id_mentor = "38";
         Map<String, String> mapChanges = new HashMap<>();
-//        mapChanges.put("id", "115");
+
         mapChanges.put("firstName", "fsdadsa_1");
         mapChanges.put("lastName", "fvcdsfvds");
         mapChanges.put("email", "asddasdvhgvhj@gmail.com");
@@ -30,7 +30,6 @@ public class WHAT_163 extends BaseTest {
                 when().put("https://whatbackend.azurewebsites.net/api/mentors/" + id_mentor).
                 then().assertThat().statusCode(200).
 
-//                and().body("id", equalTo(mapChanges.get("id"))).
                 and().body("firstName", hasToString(mapChanges.get("firstName"))).
                 and().body("lastName",  hasToString(mapChanges.get("lastName"))).
                 and().body("email",     hasToString(mapChanges.get("email"))).

--- a/src/main/java/api_tests/mentor/WHAT_163.java
+++ b/src/main/java/api_tests/mentor/WHAT_163.java
@@ -1,0 +1,43 @@
+package api_tests.mentor;
+
+
+import api_tests.BaseTest;
+import io.restassured.http.ContentType;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+
+public class WHAT_163 extends BaseTest {
+
+    @Test
+    public void updateInformationAboutMentors200Admin(){
+        String id_mentor = "38";
+        Map<String, String> mapChanges = new HashMap<>();
+//        mapChanges.put("id", "115");
+        mapChanges.put("newMentorFirstName", "fn_1");
+        mapChanges.put("newMentorLastName", "fvcdsfvds");
+        mapChanges.put("newMentorEmail", "sasdsadfadf@gmail.com");
+
+
+        given().
+                header("Authorization", getAdminToken()).
+                contentType(ContentType.JSON).
+                body(mapChanges).
+                when().put("https://whatbackend.azurewebsites.net/api/mentors/  " + id_mentor).
+                then().assertThat().statusCode(200).
+
+//                and().body("id", equalTo(mapChanges.get("id"))).
+                and().body("firstName", hasToString(mapChanges.get("newMentorFirstName"))).
+                and().body("lastName",  hasToString(mapChanges.get("newMentorLastName"))).
+                and().body("email",     hasToString(mapChanges.get("newMentorEmail"))).
+
+
+                and().log().body();
+    }
+}
+

--- a/src/main/java/api_tests/mentor/WHAT_163.java
+++ b/src/main/java/api_tests/mentor/WHAT_163.java
@@ -18,22 +18,22 @@ public class WHAT_163 extends BaseTest {
         String id_mentor = "38";
         Map<String, String> mapChanges = new HashMap<>();
 //        mapChanges.put("id", "115");
-        mapChanges.put("newMentorFirstName", "fn_1");
-        mapChanges.put("newMentorLastName", "fvcdsfvds");
-        mapChanges.put("newMentorEmail", "sasdsadfadf@gmail.com");
+        mapChanges.put("firstName", "fsdadsa_1");
+        mapChanges.put("lastName", "fvcdsfvds");
+        mapChanges.put("email", "asddasdvhgvhj@gmail.com");
 
 
         given().
                 header("Authorization", getAdminToken()).
                 contentType(ContentType.JSON).
                 body(mapChanges).
-                when().put("https://whatbackend.azurewebsites.net/api/mentors/  " + id_mentor).
+                when().put("https://whatbackend.azurewebsites.net/api/mentors/" + id_mentor).
                 then().assertThat().statusCode(200).
 
 //                and().body("id", equalTo(mapChanges.get("id"))).
-                and().body("firstName", hasToString(mapChanges.get("newMentorFirstName"))).
-                and().body("lastName",  hasToString(mapChanges.get("newMentorLastName"))).
-                and().body("email",     hasToString(mapChanges.get("newMentorEmail"))).
+                and().body("firstName", hasToString(mapChanges.get("firstName"))).
+                and().body("lastName",  hasToString(mapChanges.get("lastName"))).
+                and().body("email",     hasToString(mapChanges.get("email"))).
 
 
                 and().log().body();

--- a/src/main/java/api_tests/mentor/WHAT_163.java
+++ b/src/main/java/api_tests/mentor/WHAT_163.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 
 public class WHAT_163 extends BaseTest {

--- a/src/main/java/api_tests/mentor/WHAT_172.java
+++ b/src/main/java/api_tests/mentor/WHAT_172.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.hasToString;
 public class WHAT_172 extends BaseTest {
 
     @Test
-    public void getNotAssigned200Admin(){
+    public void resumeMentor200Admin(){
         String id_mentor = "38";
 
         given().

--- a/src/main/java/api_tests/mentor/WHAT_172.java
+++ b/src/main/java/api_tests/mentor/WHAT_172.java
@@ -1,0 +1,25 @@
+package api_tests.mentor;
+
+
+import api_tests.BaseTest;
+import org.testng.annotations.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasToString;
+
+public class WHAT_172 extends BaseTest {
+
+    @Test
+    public void getNotAssigned200Admin(){
+        String id_mentor = "38";
+
+        given().
+                header("Authorization",getAdminToken()).
+                when().delete("https://whatbackend.azurewebsites.net/api/mentors/" + id_mentor).
+                then().assertThat().statusCode(200).
+                and().assertThat().body(hasToString("true")).
+
+
+                and().log().body();
+    }
+}

--- a/src/main/java/api_tests/mentor/WHAT_186.java
+++ b/src/main/java/api_tests/mentor/WHAT_186.java
@@ -9,24 +9,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 
 public class WHAT_186 extends BaseTest {
 
     @Test
     public void createMentor200Admin(){
-        int id_mentor = 117;
+        int id_notAssigned = 119;
         Map <String, String> courseMap = new HashMap<>();
-        courseMap.put("role","2");
+        courseMap.put("newUserRole","2");
 
         given().
                 header("Authorization",getAdminToken()).
                 contentType(ContentType.JSON).
                 body(courseMap).
-                when().post("https://whatbackend.azurewebsites.net/api/mentors/" + id_mentor).
+                when().post("https://whatbackend.azurewebsites.net/api/mentors/" + id_notAssigned).
                 then().assertThat().statusCode(200).
-                and().body("role", hasToString(courseMap.get("role"))).
+
+                and().body("role", hasToString(courseMap.get("newUserRole"))).
+
                 and().log().body();
     }
 }

--- a/src/main/java/api_tests/mentor/WHAT_186.java
+++ b/src/main/java/api_tests/mentor/WHAT_186.java
@@ -1,0 +1,32 @@
+package api_tests.mentor;
+
+
+import api_tests.BaseTest;
+import io.restassured.http.ContentType;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+
+public class WHAT_186 extends BaseTest {
+
+    @Test
+    public void createMentor200Admin(){
+        int id_mentor = 117;
+        Map <String, String> courseMap = new HashMap<>();
+        courseMap.put("role","2");
+
+        given().
+                header("Authorization",getAdminToken()).
+                contentType(ContentType.JSON).
+                body(courseMap).
+                when().post("https://whatbackend.azurewebsites.net/api/mentors/" + id_mentor).
+                then().assertThat().statusCode(200).
+                and().body("role", hasToString(courseMap.get("role"))).
+                and().log().body();
+    }
+}

--- a/src/main/java/api_tests/mentor/WHAT_186.java
+++ b/src/main/java/api_tests/mentor/WHAT_186.java
@@ -15,18 +15,18 @@ public class WHAT_186 extends BaseTest {
 
     @Test
     public void createMentor200Admin(){
-        int id_notAssigned = 119;
-        Map <String, String> courseMap = new HashMap<>();
-        courseMap.put("newUserRole","2");
+        int id_notAssigned = 122;
+        Map <String, String> mentorMap = new HashMap<>();
+        mentorMap.put("newUserRole","2");
 
         given().
                 header("Authorization",getAdminToken()).
                 contentType(ContentType.JSON).
-                body(courseMap).
+                body(mentorMap).
                 when().post("https://whatbackend.azurewebsites.net/api/mentors/" + id_notAssigned).
                 then().assertThat().statusCode(200).
 
-                and().body("role", hasToString(courseMap.get("newUserRole"))).
+                and().body("role", hasToString(mentorMap.get("newUserRole"))).
 
                 and().log().body();
     }

--- a/src/main/java/api_tests/unassigned/WHAT_175.java
+++ b/src/main/java/api_tests/unassigned/WHAT_175.java
@@ -11,6 +11,7 @@ public class WHAT_175 extends BaseTest {
 
     @Test
     public void getNotAssigned200Admin(){
+
         String[] notAssignedUserID = new String[] {"115", "116"};
         String[] notAssignedUserFirstName = new String[] {"FirstName", "John"};
         String[] notAssignedUserLastName = new String[] {"LastName", "Doe"};


### PR DESCRIPTION
create WHAT_163, WHAT_172, WHAT_186


WHAT_172.java This test case verifies that the Administrator user can disable the Mentor by making DELETE request to the REST endpoint.
WHAT_163.java This test case verifies that Admin users can update information about mentors by making PUT
request to REST endpoint.
WHAT_186.java This test case verifies that Administrator can assign mentor role for unassigned account by making POST request to REST endpoint.